### PR TITLE
Bugfix: Fixes rendering if effect changes while sheet open

### DIFF
--- a/Source/Utils/Updater.ts
+++ b/Source/Utils/Updater.ts
@@ -1,4 +1,4 @@
-import { FUData } from "../types";
+import { FUData, isFUActor } from "../types";
 import Logger from "./Logger";
 
 class FUObjectUpdater {
@@ -30,7 +30,17 @@ class FUObjectUpdater {
 	public updateAttached(actorID: string): void {
 		if (!this.toBeUpdated[actorID]) return;
 
-		this.toBeUpdated[actorID].forEach((object) => object.prepareData());
+		this.toBeUpdated[actorID].forEach((object) => {
+			object.prepareData();
+
+			if (object.sheet.rendered) {
+				object.sheet.render(false);
+			}
+
+			if (object.parent && object.parent.sheet.rendered) {
+				object.parent.sheet.render(false);
+			}
+		});
 	}
 }
 

--- a/Source/types.ts
+++ b/Source/types.ts
@@ -13,6 +13,10 @@ export interface FUData {
 	id: string;
 	name: string;
 	prepareData: () => void;
+	sheet: {
+		render: (force: boolean) => void;
+		rendered: boolean;
+	};
 }
 
 export interface FUSkill extends FUData {


### PR DESCRIPTION
This pull request has a bug fix for effects.

Previously, if an effect changed that targeted an actor outside of where the effect was attached, its data would change, but if the sheet was open it would not render it.

Now it does.